### PR TITLE
Fix buffer overflow error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 This gem is a mutation of the [fluent-plugin-buffer-lightening](https://github.com/tagomoris/fluent-plugin-buffer-lightening) buffer plugin by [tagomoris](https://github.com/tagomoris).
 
-[Fluentd](http://fluentd.org) buffer plugin on memory to flush with many types of chunk limit methods:
-  * events count limit in chunk
-
-These options are to decrease latency from emit to write, and to control chunk sizes and flush sizes.
+* The buffer is able to limit the number of events that are buffered in a buffer chunk.
+* The buffer only supports output plugins that return msgpack from their `#format` methods.
+* The buffer doesn't check the bytesize of the buffers just the number of messages
 
 ## Installation
 
@@ -33,9 +32,6 @@ Options of `buffer_type file` are also available:
   buffer_type event_limited
   buffer_chunk_limit 10M
   buffer_chunk_records_limit 100
-  buffer_chunk_message_separator newline
-  # buffer_chunk_message_separator tab
-  # buffer_chunk_message_separator msgpack
   # other options...
 </match>
 ```

--- a/test/plugin/test_buf_event_limited.rb
+++ b/test/plugin/test_buf_event_limited.rb
@@ -23,13 +23,12 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
     FileUtils.rmdir @buffer_path
   end
 
-  def default_config(sep = 'newline')
+  def default_config
     %[
       buffer_type event_limited
       flush_interval 0.1
       try_flush_interval 0.03
       buffer_chunk_records_limit 10
-      buffer_chunk_message_separator #{sep}
       buffer_path #{@buffer_path}
     ]
   end
@@ -43,7 +42,6 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
   def create_buffer_with_attributes(config = {})
     config = {
       'buffer_path' => @buffer_path,
-      'buffer_chunk_message_separator' => 'newline'
     }.merge(config)
     buf = Fluent::EventLimitedFileBuffer.new
     Fluent::EventLimitedFileBuffer.send(:class_variable_set, :'@@buffer_paths', {})
@@ -62,13 +60,12 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
     assert_equal 0.1,  output.flush_interval
     assert_equal 0.03, output.try_flush_interval
     assert_equal 10,   buffer.buffer_chunk_records_limit
-    assert_equal 'newline', buffer.buffer_chunk_message_separator
   end
 
   def test_emit
-    d = create_driver(default_config('msgpack'))
+    d = create_driver
     buffer = d.instance.instance_variable_get(:@buffer)
-    count_buffer_events = -> { buffer.instance_variable_get(:@map)[''].record_counter }
+    count_buffer_events = -> { buffer.instance_variable_get(:@map)[''].record_count }
 
     buffer.start
     assert_nil buffer.instance_variable_get(:@map)[''], "No chunks on start"
@@ -97,12 +94,12 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
   end
 
   def test_emit_with_oversized_streams
-    d = create_driver(default_config('msgpack'))
+    d = create_driver
     buffer = d.instance.instance_variable_get(:@buffer)
     chain = DummyChain.new
     tag = d.instance.instance_variable_get(:@tag)
     time = Time.now.to_i
-    count_buffer_events = -> { buffer.instance_variable_get(:@map)[''].record_counter }
+    count_buffer_events = -> { buffer.instance_variable_get(:@map)[''].record_count }
     count_queued_buffers = -> { buffer.instance_variable_get(:@queue).size }
 
     buffer.start
@@ -112,7 +109,7 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
     assert buffer.emit(tag, event_stream, chain), "Should trigger flush"
     assert_equal 2, count_queued_buffers.call, "Data should fill up two buffers"
     assert_equal 1, count_buffer_events.call, "Data should overflow into a new buffer"
-    assert buffer.instance_variable_get(:@queue).all? { |b| b.record_counter == 10 }
+    assert buffer.instance_variable_get(:@queue).all? { |b| b.record_count == 10 }
   end
 
   def test_new_chunk
@@ -126,7 +123,10 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
     assert chunk1.path != chunk2.path
   end
 
-  def test_resume_from_plain_text_chunk
+  def test_resume_from_msgpack_chunks
+    d = create_driver
+    events = 2.times.map { |i| [Time.now.to_i, {a: i}] }
+    event_stream = d.instance.format_stream('test', events)
     # Setup buffer to test chunks
     buf1, prefix, suffix = create_buffer_with_attributes
     buf1.start
@@ -134,75 +134,23 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
     # Create chunks to test
     chunk1 = buf1.new_chunk('key1')
     chunk2 = buf1.new_chunk('key2')
-    assert_equal 0, chunk1.record_counter
-    assert_equal 0, chunk2.record_counter
+    assert_equal 0, chunk1.record_count
+    assert_equal 0, chunk2.record_count
 
     # Write data into chunks
-    chunk1 << "data1\ndata2\n"
-    chunk2 << "data3\ndata4\n"
+    chunk1.write(event_stream, 2)
+    chunk2.write(event_stream, 2)
 
     # Enqueue chunk1 and leave chunk2 open
     buf1.enqueue(chunk1)
-    assert \
+    assert(
       chunk1.path =~ /\A#{prefix}[-_.a-zA-Z0-9\%]+\.q[0-9a-f]+#{suffix}\Z/,
       "chunk1 must be enqueued"
-    assert \
+    )
+    assert(
       chunk2.path =~ /\A#{prefix}[-_.a-zA-Z0-9\%]+\.b[0-9a-f]+#{suffix}\Z/,
       "chunk2 is not enqueued yet"
-    buf1.shutdown
-
-    # Setup a new buffer to test resume
-    buf2, *_ = create_buffer_with_attributes
-    queue, map = buf2.resume
-
-    # Returns with the open and the closed buffers
-    assert_equal 1, queue.size # closed buffer
-    assert_equal 1, map.values.size # open buffer
-
-    # The paths of the resumed chunks are the same but they themselfs are not
-    resumed_chunk1 = queue.first
-    resumed_chunk2 = map.values.first
-    assert_equal chunk1.path, resumed_chunk1.path
-    assert_equal chunk2.path, resumed_chunk2.path
-    assert chunk1 != resumed_chunk1
-    assert chunk2 != resumed_chunk2
-
-    # Resume with the proper type of buffer chunk
-    assert_equal Fluent::EventLimitedBufferChunk, resumed_chunk1.class
-    assert_equal Fluent::EventLimitedBufferChunk, resumed_chunk2.class
-
-    assert_equal "data1\ndata2\n", resumed_chunk1.read
-    assert_equal "data3\ndata4\n", resumed_chunk2.read
-
-    assert_equal 2, resumed_chunk1.record_counter
-    assert_equal 2, resumed_chunk2.record_counter
-  end
-
-  def test_resume_from_msgpack_chunks
-    # Setup buffer to test chunks
-    buf1, prefix, suffix = create_buffer_with_attributes({'buffer_chunk_message_separator' => 'msgpack'})
-    buf1.start
-
-    # Create chunks to test
-    chunk1 = buf1.new_chunk('key1')
-    chunk2 = buf1.new_chunk('key2')
-    assert_equal 0, chunk1.record_counter
-    assert_equal 0, chunk2.record_counter
-
-    # Write data into chunks
-    chunk1 << MessagePack.pack('data1')
-    chunk1 << MessagePack.pack('data2')
-    chunk2 << MessagePack.pack('data3')
-    chunk2 << MessagePack.pack('data4')
-
-    # Enqueue chunk1 and leave chunk2 open
-    buf1.enqueue(chunk1)
-    assert \
-      chunk1.path =~ /\A#{prefix}[-_.a-zA-Z0-9\%]+\.q[0-9a-f]+#{suffix}\Z/,
-      "chunk1 must be enqueued"
-    assert \
-      chunk2.path =~ /\A#{prefix}[-_.a-zA-Z0-9\%]+\.b[0-9a-f]+#{suffix}\Z/,
-      "chunk2 is not enqueued yet"
+    )
     buf1.shutdown
 
     # Setup a new buffer to test resume
@@ -225,14 +173,10 @@ class EventLimitedFileBufferTest < Test::Unit::TestCase
     assert_equal Fluent::EventLimitedBufferChunk, resumed_chunk1.class
     assert_equal Fluent::EventLimitedBufferChunk, resumed_chunk2.class
 
-    assert_equal \
-      MessagePack.pack('data1') + MessagePack.pack('data2'),
-      resumed_chunk1.read
-    assert_equal \
-      MessagePack.pack('data3') + MessagePack.pack('data4'),
-      resumed_chunk2.read
+    assert_equal event_stream, resumed_chunk1.read
+    assert_equal event_stream, resumed_chunk2.read
 
-    assert_equal 2, resumed_chunk1.record_counter
-    assert_equal 2, resumed_chunk2.record_counter
+    assert_equal 2, resumed_chunk1.record_count
+    assert_equal 2, resumed_chunk2.record_count
   end
 end


### PR DESCRIPTION
Fluentd has an undocumented behaviour, which will write to the buffer even when the `storable?` predicate returns false. This behaviour corrupts the whole plugin, to fix this I rewrote the `buf#emit` method to break the incoming data stream into multiple chunks. To break up the incoming stream I have to unpack the passed data.

Consequences:
- the plugin is a bit slower because of the `pack -> unpack -> pack again`
- doesn't work with output plugins that format the events into non MessagePack format